### PR TITLE
Fix bin script name

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "bin": {
     "morph": "index.js",
-    "levelmorpher": "index.js"
+    "levenmorpher": "index.js"
   },
   "repository": "zeke/levenmorpher",
   "scripts": {


### PR DESCRIPTION
package.json currently installs the CLI as "levelmorpher" with "level" as in "level-headed". This tiny patch corrects the name to "levenmorpher", to match the package name and README.
